### PR TITLE
Create main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Make sure the actual branch is checked out when running on pull requests
+          ref: ${{ github.head_ref }}
+          # This is important to fetch the changes to the previous commit
+          fetch-depth: 0
+
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.3
+        with:
+          # Parámetros obtenidos de: https://github.com/marketplace/actions/prettier-action
+          prettier_options: --write **/*.{js,jsx,tsx,ts,md}
+          same_commit: True
+          only_changed: True


### PR DESCRIPTION
## Github Actions

Armé un trabajo "Prettier" que formatea el código cuando se hace una PR a la rama main.
No sé si funciona, saqué el template de https://github.com/marketplace/actions/prettier-action

Esto hace que todos veamos el código con el mismo formato, y que ese formateo sea algo automático. Así, **ya no es responsabilidad de nadie formatear su código, porque ahora es automático**.

Si a alguien le interesa indagar más sobre Github Actions: https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions