### PR TITLE
Reservas backend

### DIFF
--- a/backend/prisma/migrations/20230909235350_actualizado_modelo_reserva/migration.sql
+++ b/backend/prisma/migrations/20230909235350_actualizado_modelo_reserva/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `horaFin` on the `reserva` table. All the data in the column will be lost.
+  - You are about to drop the column `horaInicio` on the `reserva` table. All the data in the column will be lost.
+  - You are about to drop the column `idCancha` on the `reserva` table. All the data in the column will be lost.
+  - You are about to drop the column `idDisciplina` on the `reserva` table. All the data in the column will be lost.
+  - Added the required column `idDisponibilidad` to the `reserva` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "reserva" DROP CONSTRAINT "reserva_idCancha_fkey";
+
+-- DropForeignKey
+ALTER TABLE "reserva" DROP CONSTRAINT "reserva_idDisciplina_fkey";
+
+-- AlterTable
+ALTER TABLE "reserva" DROP COLUMN "horaFin",
+DROP COLUMN "horaInicio",
+DROP COLUMN "idCancha",
+DROP COLUMN "idDisciplina",
+ADD COLUMN     "idDisponibilidad" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "reserva" ADD CONSTRAINT "reserva_idDisponibilidad_fkey" FOREIGN KEY ("idDisponibilidad") REFERENCES "disponibilidad"("idDisponibilidad") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/backend/prisma/migrations/20230910000318_precio_de_reserva_ahora_es_decimal/migration.sql
+++ b/backend/prisma/migrations/20230910000318_precio_de_reserva_ahora_es_decimal/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `precio` on the `reserva` table. The data in that column could be lost. The data in that column will be cast from `DoublePrecision` to `Decimal`.
+
+*/
+-- AlterTable
+ALTER TABLE "reserva" ALTER COLUMN "precio" SET DATA TYPE DECIMAL;

--- a/backend/prisma/migrations/20230910224248_unique_compuesto_entre_id_disponibilidad_y_fecha_reserva_en_reserva/migration.sql
+++ b/backend/prisma/migrations/20230910224248_unique_compuesto_entre_id_disponibilidad_y_fecha_reserva_en_reserva/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[idDisponibilidad,fechaReserva]` on the table `reserva` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "reserva_idDisponibilidad_fechaReserva_key" ON "reserva"("idDisponibilidad", "fechaReserva");

--- a/backend/prisma/migrations/20230911004412_agregado_atributo_fecha_creada_a_reserva/migration.sql
+++ b/backend/prisma/migrations/20230911004412_agregado_atributo_fecha_creada_a_reserva/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `fechaReserva` on the `reserva` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[idDisponibilidad,fechaReservada]` on the table `reserva` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `fechaReservada` to the `reserva` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "reserva_idDisponibilidad_fechaReserva_key";
+
+-- AlterTable
+ALTER TABLE "reserva" DROP COLUMN "fechaReserva",
+ADD COLUMN     "fechaCreada" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "fechaReservada" DATE NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "reserva_idDisponibilidad_fechaReservada_key" ON "reserva"("idDisponibilidad", "fechaReservada");

--- a/backend/prisma/migrations/20230911032122_id_pago_reserva_en_reserva_ahora_es_opcional/migration.sql
+++ b/backend/prisma/migrations/20230911032122_id_pago_reserva_en_reserva_ahora_es_opcional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "reserva" ALTER COLUMN "idPagoReserva" DROP NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -36,13 +36,11 @@ model cancha {
   idEstablecimiento Int
   establecimiento   establecimiento  @relation(fields: [idEstablecimiento], references: [id], onDelete: NoAction, onUpdate: NoAction)
   disponibilidades  disponibilidad[]
-  reservas          reserva[]
 }
 
 model disciplina {
   disciplina String @id @db.VarChar
 
-  reservas         reserva[]
   disponibilidades disponibilidad[]
 }
 
@@ -58,6 +56,7 @@ model disponibilidad {
   idDisciplina String     @map("disciplina") @db.VarChar
   disciplina   disciplina @relation(fields: [idDisciplina], references: [disciplina])
   dias         dia[]
+  reservas     reserva[]
 }
 
 model dia {
@@ -154,22 +153,21 @@ model suscripcion {
 }
 
 model reserva {
-  id           Int      @id @default(autoincrement()) @map("idReserva")
-  fechaReserva DateTime @db.Date
-  horaInicio   DateTime @db.Time(6)
-  horaFin      DateTime @db.Time(6)
-  precio       Float
+  id             Int      @id @default(autoincrement()) @map("idReserva")
+  fechaCreada    DateTime @default(now()) // Fecha en la que se creó la reserva.
+  fechaReservada DateTime @db.Date // Fecha en la que el jugador va a ocupar la disponibilidad reservada.
+  precio         Decimal  @db.Decimal
 
-  idCancha      Int
-  cancha        cancha     @relation(fields: [idCancha], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  idJugador     Int
-  jugador       jugador    @relation(fields: [idJugador], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  idDisciplina  String     @db.VarChar
-  disciplina    disciplina @relation(fields: [idDisciplina], references: [disciplina], onDelete: NoAction, onUpdate: NoAction)
-  idPagoReserva Int
-  pagoReserva   pago?      @relation("pagoReserva", fields: [idPagoReserva], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  idPagoSenia   Int?
-  pagoSenia     pago?      @relation("pagoSenia", fields: [idPagoSenia], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  idDisponibilidad Int
+  disponibilidad   disponibilidad @relation(fields: [idDisponibilidad], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  idJugador        Int
+  jugador          jugador        @relation(fields: [idJugador], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  idPagoReserva    Int?
+  pagoReserva      pago?          @relation("pagoReserva", fields: [idPagoReserva], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  idPagoSenia      Int?
+  pagoSenia        pago?          @relation("pagoSenia", fields: [idPagoSenia], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@unique([idDisponibilidad, fechaReservada])
 }
 
 model tarjeta {

--- a/backend/src/handlers/auth.ts
+++ b/backend/src/handlers/auth.ts
@@ -15,7 +15,7 @@ export const registrarAdminSchema = administradorSchema
   });
 
 // Se puede iniciar sesión o con usuario o con correo.
-export const loginReqSchema = z.object({
+export const loginSchema = z.object({
   correoOUsuario: z.string().nonempty(),
   clave: z.string().nonempty(),
 });
@@ -26,11 +26,11 @@ export const registrarJugadorSchema = jugadorSchema
   })
   .omit({ id: true });
 
-type LoginReq = z.infer<typeof loginReqSchema>;
+type Login = z.infer<typeof loginSchema>;
 
-type RegistrarAdminReq = z.infer<typeof registrarAdminSchema>;
+type RegistrarAdmin = z.infer<typeof registrarAdminSchema>;
 
-type RegistrarJugadorReq = z.infer<typeof registrarJugadorSchema>;
+type RegistrarJugador = z.infer<typeof registrarJugadorSchema>;
 
 export class AuthHandler {
   private service: AuthService;
@@ -43,7 +43,7 @@ export class AuthHandler {
 
   login(): RequestHandler {
     return async (_req, res) => {
-      const loginReq: LoginReq = res.locals.body;
+      const loginReq: Login = res.locals.body;
 
       const token = await this.service.loginUsuario(
         loginReq.correoOUsuario,
@@ -55,7 +55,6 @@ export class AuthHandler {
 
   refreshToken(): RequestHandler {
     return async (req, res) => {
-      // El Authorization header es válido, sino no hubiera pasado el auth middleware.
       const currentToken = req.header("Authorization")?.replace("Bearer ", "")!;
 
       const token = await this.service.refreshJWT(currentToken);
@@ -65,7 +64,7 @@ export class AuthHandler {
 
   registerAdmin(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const body: RegistrarAdminReq = res.locals.body;
+      const body: RegistrarAdmin = res.locals.body;
 
       // Se obtiene la suscripcion mediante el idSuscripcion.
       const sus = await this.susService.getSuscripcionByID(body.idSuscripcion);
@@ -73,12 +72,9 @@ export class AuthHandler {
       // Se construye el Administrador del modelo.
       const admin: Administrador = {
         ...body,
-        tarjeta: {
-          id: 0,
-          ...body.tarjeta,
-        },
-        id: 0,
         suscripcion: sus,
+        tarjeta: { ...body.tarjeta, id: 0 },
+        id: 0,
       };
 
       const adminCreado = await this.service.registrarAdministrador(
@@ -91,13 +87,10 @@ export class AuthHandler {
 
   registerJugador(): RequestHandler {
     return async (_req: Request, res: Response) => {
-      const body: RegistrarJugadorReq = res.locals.body;
+      const body: RegistrarJugador = res.locals.body;
 
       // Se construye el Jugador del modelo.
-      const jugador: Jugador = {
-        ...body,
-        id: 0,
-      };
+      const jugador: Jugador = { ...body, id: 0 };
 
       const jugadorCreado = await this.service.registrarJugador(
         jugador,

--- a/backend/src/handlers/canchas.ts
+++ b/backend/src/handlers/canchas.ts
@@ -4,7 +4,7 @@ import { Cancha, canchaSchema } from "../models/cancha.js";
 import { z } from "zod";
 import { disponibilidadSchema } from "../models/disponibilidad.js";
 
-export const crearCanchaReqSchema = canchaSchema
+export const crearCanchaSchema = canchaSchema
   .omit({
     id: true,
     urlImagen: true,
@@ -14,7 +14,7 @@ export const crearCanchaReqSchema = canchaSchema
     disponibilidades: z.array(disponibilidadSchema.omit({ id: true })),
   });
 
-export const modificarCanchaReqSchema = canchaSchema
+export const modificarCanchaSchema = canchaSchema
   .omit({
     id: true,
     urlImagen: true,

--- a/backend/src/handlers/disponibilidades.ts
+++ b/backend/src/handlers/disponibilidades.ts
@@ -5,11 +5,11 @@ import {
   disponibilidadSchema,
 } from "../models/disponibilidad.js";
 
-export const crearDisponibilidadReqSchema = disponibilidadSchema.omit({
+export const crearDisponibilidadSchema = disponibilidadSchema.omit({
   id: true,
 });
 
-export const modificarDisponibilidadReqSchema = disponibilidadSchema;
+export const modificarDisponibilidadSchema = disponibilidadSchema;
 
 export class DisponibilidadHandler {
   private service: DisponibilidadService;

--- a/backend/src/handlers/establecimientos.ts
+++ b/backend/src/handlers/establecimientos.ts
@@ -6,16 +6,15 @@ import {
 } from "../models/establecimiento.js";
 import { ForbiddenError } from "../utils/apierrors.js";
 
-export const crearEstablecimientoReqSchema = establecimientoSchema.omit({
+export const crearEstablecimientoSchema = establecimientoSchema.omit({
   id: true,
   urlImagen: true,
   eliminado: true,
 });
 
-export const modificarEstablecimientoReqSchema = establecimientoSchema.omit({
+export const modificarEstablecimientoSchema = establecimientoSchema.omit({
   urlImagen: true,
   id: true,
-  //eliminado: true,
 });
 
 export class EstablecimientoHandler {

--- a/backend/src/handlers/reservas.ts
+++ b/backend/src/handlers/reservas.ts
@@ -1,0 +1,67 @@
+import { RequestHandler } from "express";
+import { z } from "zod";
+import { CrearReserva, ReservaService } from "../services/reservas";
+import { BadRequestError } from "../utils/apierrors";
+
+export const crearReservaSchema = z.object({
+  idDisponibilidad: z.number().positive().int(),
+  fechaReservada: z.coerce.date(),
+});
+
+export const getReservaQuerySchema = z.object({
+  idJugador: z.coerce.number().positive().int().optional(),
+  idDisp: z.coerce.number().positive().int().optional(),
+  idEst: z.coerce.number().positive().int().optional(),
+});
+
+type GetReservaQuery = z.infer<typeof getReservaQuerySchema>;
+
+export class ReservaHandler {
+  private service: ReservaService;
+
+  constructor(service: ReservaService) {
+    this.service = service;
+  }
+
+  getReserva(): RequestHandler {
+    return async (_req, res) => {
+      const query: GetReservaQuery = res.locals.query;
+      let reserva;
+      if (query.idDisp) {
+        reserva = await this.service.getByDisponibilidadID(query.idDisp);
+      } else if (query.idEst) {
+        reserva = await this.service.getByEstablecimientoID(query.idEst);
+      } else if (query.idJugador) {
+        reserva = await this.service.getByJugadorID(query.idJugador);
+      } else {
+        throw new BadRequestError(
+          "Especificar un query param: 'idJugador', 'idDisp' o 'idEst'."
+        );
+      }
+
+      res.status(200).json(reserva);
+    };
+  }
+
+  getReservaByID(): RequestHandler {
+    return async (req, res) => {
+      const idReserva = Number(req.params["idRes"]);
+
+      const reserva = await this.service.getByID(idReserva);
+      res.status(200).json(reserva);
+    };
+  }
+
+  postReserva(): RequestHandler {
+    return async (_req, res) => {
+      const crearReserva: CrearReserva = res.locals.body;
+      const idJugador = res.locals.idJugador;
+
+      const reservaCreada = await this.service.crear({
+        ...crearReserva,
+        idJugador,
+      });
+      res.status(201).json(reservaCreada);
+    };
+  }
+}

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -31,11 +31,42 @@ export class AuthMiddleware {
       if (!roles.includes(Rol.Administrador)) {
         return res
           .status(403)
-          .send(new ForbiddenError("No tiene los permisos necesarios"));
+          .send(new ForbiddenError("No tiene el rol Administrador"));
       }
 
       // Los handlers subsiguientes tienen acceso al idAdmin que vino en el JWT.
       res.locals.idAdmin = Number(jwt?.admin?.id);
+      next();
+    };
+  }
+
+  /**
+   * Valida que la request tenga un JWT válido y que sea de un usuario **jugador**.
+   * Setea `res.locals.idJugador` con el idJugador que vino en el JWT.
+   */
+  public isJugador(): Handler {
+    return async (req, res, next) => {
+      const token = req.header("Authorization")?.replace("Bearer ", "");
+      if (!token) {
+        return res
+          .status(401)
+          .send(new UnauthorizedError("Authorization header inválido"));
+      }
+
+      const jwt = await this.service.verifyJWT(token);
+      if (jwt == null) {
+        return res.status(401).send(new UnauthorizedError("Token inválido"));
+      }
+
+      const roles = this.service.getRolesFromJWT(token);
+      if (!roles.includes(Rol.Jugador)) {
+        return res
+          .status(403)
+          .send(new ForbiddenError("No tiene el rol Jugador"));
+      }
+
+      // Los handlers subsiguientes tienen acceso al idJugador que vino en el JWT.
+      res.locals.idJugador = Number(jwt?.jugador?.id);
       next();
     };
   }

--- a/backend/src/middlewares/errors.ts
+++ b/backend/src/middlewares/errors.ts
@@ -2,9 +2,9 @@ import { Request, Response, NextFunction, ErrorRequestHandler } from "express";
 import { ApiError, InternalServerError } from "../utils/apierrors.js";
 
 function logError(error: ApiError, req: Request, res: Response) {
-  console.error("⛔ ApiError: ", error);
-  console.error("⛔ Body: ", res.locals.body);
-  console.error("⛔ URL: ", req.url);
+  console.error("⛔ ApiError:", error);
+  console.error("⛔ Body validado:", res.locals.body);
+  console.error("⛔ URI:", req.url);
 }
 /**
  * Este middleware ataja los errores que sucedan en la aplicación,

--- a/backend/src/middlewares/validation.ts
+++ b/backend/src/middlewares/validation.ts
@@ -25,8 +25,36 @@ export function validateBody(schema: AnyZodObject) {
 }
 
 /**
- * Valida que los nombres de los params pasados por parámetro sean números enteros positivos.
- * Ej: 'idAdmin', 'idCancha'. En caso contrario, devuelve un 404 Bad Request.
+ * Valida que el objeto query params recibido cumpla con un zod schema.
+ * Si es válido, **guarda el query parseado en `res.locals.query`**.
+ *
+ * Nota: todos los query params son strings para HTTP.
+ * Conviene usar `z.coerce...` para pasar esos strings a un `number`, `boolean`, etc.
+ * Ref: https://zod.dev/?id=coercion-for-primitives
+ *
+ * @param schema - el zod Schema a validar contra los query params.
+ */
+export function validateQueryParams(schema: AnyZodObject) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.query);
+
+    if (!result.success) {
+      const issues = result.error.issues;
+      const msg = issues
+        .map((issue) => `Query param ${issue.path}: ${issue.message}`)
+        .join("; ");
+      throw new BadRequestError(msg);
+    }
+
+    res.locals.query = result.data;
+    next();
+  };
+}
+
+/**
+ * Valida que los path params sean números enteros positivos.
+ * Si uno no cumple, devuelve un 404 Bad Request.
+ * @param params los path params a validar. Ej: `idEst` de '/establecimientos/:idEst'.
  */
 export function validateIDParams(...params: string[]) {
   return (req: Request, _res: Response, next: NextFunction) => {
@@ -34,7 +62,7 @@ export function validateIDParams(...params: string[]) {
       let idParam = Number(req.params[p]);
       if (!idParam || idParam <= 0) {
         throw new BadRequestError(
-          `El parámetro '${p}': ${req.params[p]} debe ser un número entero positivo`
+          `Parámetro '${p}': ${req.params[p]} debe ser un número entero positivo`
         );
       }
     }

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -1,6 +1,9 @@
 import Decimal from "decimal.js";
 import { z } from "zod";
 
-export const decimalSchema = z.custom<Decimal>(
-  (value: unknown) => new Decimal(value as Decimal.Value)
-);
+export const decimalSchema = z.custom<Decimal>((value) => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  return new Decimal(value as Decimal.Value);
+});

--- a/backend/src/models/reserva.ts
+++ b/backend/src/models/reserva.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { decimalSchema } from ".";
+import { jugadorSchema } from "./jugador";
+import { disponibilidadSchema } from "./disponibilidad";
+
+export type Reserva = z.infer<typeof reservaSchema>;
+
+export const reservaSchema = z.object({
+  id: z.number().int().positive(),
+  precio: decimalSchema,
+  fechaReservada: z.date(),
+  fechaCreada: z.date(),
+  jugador: jugadorSchema,
+  disponibilidad: disponibilidadSchema,
+});

--- a/backend/src/repositories/canchas.ts
+++ b/backend/src/repositories/canchas.ts
@@ -12,6 +12,7 @@ import { DisponibilidadRepository } from "./disponibilidades.js";
 
 export interface CanchaRepository {
   getCanchasByEstablecimientoID(idEst: number): Promise<Cancha[]>;
+  getCanchaByDisponibilidadID(idDisp: number): Promise<Cancha>;
   getCanchaByID(idCancha: number): Promise<Cancha>;
   crearCancha(cancha: Cancha): Promise<Cancha>;
   modificarCancha(canchaUpdate: Cancha): Promise<Cancha>;
@@ -63,6 +64,12 @@ export class PrismaCanchaRepository implements CanchaRepository {
       `No existe cancha con id ${idCancha}`,
       "Error al intentar obtener la cancha"
     );
+  }
+
+  async getCanchaByDisponibilidadID(idDisp: number): Promise<Cancha> {
+    const disp = await this.dispRepository.getDisponibilidadByID(idDisp);
+
+    return await this.getCanchaByID(disp.idCancha);
   }
 
   async crearCancha(cancha: Cancha): Promise<Cancha> {

--- a/backend/src/repositories/disponibilidades.ts
+++ b/backend/src/repositories/disponibilidades.ts
@@ -32,9 +32,9 @@ export class PrismaDisponibilidadRepository
         orderBy: [{ horaInicio: "asc" }],
         include: this.include,
       });
-      return canchas.map((c) => toModel(c));
+      return canchas.map((c) => toDisp(c));
     } catch {
-      throw new InternalServerError("Error listar las disponibilidades");
+      throw new InternalServerError("Error al listar las disponibilidades");
     }
   }
 
@@ -44,7 +44,7 @@ export class PrismaDisponibilidadRepository
         where: { id: idDisp },
         include: this.include,
       }),
-      `No existe cancha con id ${idDisp}`,
+      `No existe disponibilidad con id ${idDisp}`,
       "Error al intentar obtener la disponibilidad"
     );
   }
@@ -69,9 +69,9 @@ export class PrismaDisponibilidadRepository
         include: this.include,
       });
 
-      return toModel(dbDisp);
+      return toDisp(dbDisp);
     } catch {
-      throw new InternalServerError("No se pudo crear el establecimiento");
+      throw new InternalServerError("No se pudo crear la disponibilidad");
     }
   }
 
@@ -107,17 +107,17 @@ export class PrismaDisponibilidadRepository
         include: this.include,
       }),
       `No existe disponibilidad con id ${idDisp}`,
-      "Error interno al intentar eliminar la cancha"
+      "Error interno al intentar eliminar la disponibilidad"
     );
   }
 }
 
-type disponibilidadDB = Omit<disponibilidad, "idDisciplina"> & {
+export type disponibilidadDB = Omit<disponibilidad, "idDisciplina"> & {
   disciplina: disciplina;
   dias: dia[];
 };
 
-function toModel(disp: disponibilidadDB): Disponibilidad {
+export function toDisp(disp: disponibilidadDB): Disponibilidad {
   return {
     ...disp,
     disciplina: disp.disciplina.disciplina,
@@ -132,10 +132,10 @@ async function awaitQuery(
   errorMsg: string
 ): Promise<Disponibilidad> {
   try {
-    const cancha = await promise;
+    const disp = await promise;
 
-    if (cancha) {
-      return toModel(cancha);
+    if (disp) {
+      return toDisp(disp);
     }
   } catch {
     throw new InternalServerError(errorMsg);

--- a/backend/src/repositories/reservas.ts
+++ b/backend/src/repositories/reservas.ts
@@ -1,0 +1,160 @@
+import { Reserva } from "../models/reserva.js";
+import { InternalServerError, NotFoundError } from "../utils/apierrors.js";
+import { PrismaClient, jugador, reserva } from "@prisma/client";
+import { disponibilidadDB, toDisp } from "./disponibilidades.js";
+import { CrearReserva } from "../services/reservas.js";
+import Decimal from "decimal.js";
+
+export interface ReservaRepository {
+  getReservasByEstablecimientoID(idEst: number): Promise<Reserva[]>;
+  getReservasByDisponibilidadID(idDisp: number): Promise<Reserva[]>;
+  getReservasByJugadorID(idJugador: number): Promise<Reserva[]>;
+  getReservaByID(id: number): Promise<Reserva>;
+  crearReserva(res: CrearReserva & { precio: Decimal }): Promise<Reserva>;
+  existsReservaByDate(idDisp: number, fecha: Date): Promise<boolean>;
+}
+
+export class PrismaReservaRepository implements ReservaRepository {
+  private prisma: PrismaClient;
+  private include = {
+    jugador: true,
+    disponibilidad: {
+      include: {
+        disciplina: true,
+        dias: true,
+      },
+    },
+  };
+
+  constructor(prismaClient: PrismaClient) {
+    this.prisma = prismaClient;
+  }
+
+  async getReservasByDisponibilidadID(idDisp: number): Promise<Reserva[]> {
+    try {
+      const reservas = await this.prisma.reserva.findMany({
+        where: { idDisponibilidad: idDisp },
+        orderBy: [{ fechaReservada: "asc" }],
+        include: this.include,
+      });
+      return reservas.map((r) => toRes(r));
+    } catch {
+      throw new InternalServerError(
+        `Error al listar las reservas de la disponibilidad con id ${idDisp}`
+      );
+    }
+  }
+
+  async getReservasByJugadorID(idJugador: number): Promise<Reserva[]> {
+    try {
+      const reservas = await this.prisma.reserva.findMany({
+        where: { idJugador: idJugador },
+        orderBy: [{ fechaReservada: "asc" }],
+        include: this.include,
+      });
+      return reservas.map((r) => toRes(r));
+    } catch {
+      throw new InternalServerError(
+        `Error al listar las reservas del jugador con id ${idJugador}`
+      );
+    }
+  }
+
+  async getReservasByEstablecimientoID(idEst: number): Promise<Reserva[]> {
+    try {
+      const reservas = await this.prisma.reserva.findMany({
+        where: {
+          disponibilidad: { cancha: { establecimiento: { id: idEst } } },
+        },
+        orderBy: [{ fechaReservada: "asc" }],
+        include: this.include,
+      });
+      return reservas.map((r) => toRes(r));
+    } catch {
+      throw new InternalServerError(
+        `Error al listar las reservas del establecimiento con id ${idEst}`
+      );
+    }
+  }
+
+  async getReservaByID(id: number): Promise<Reserva> {
+    return awaitQuery(
+      this.prisma.reserva.findUnique({
+        where: { id },
+        include: this.include,
+      }),
+      `No existe reserva con id ${id}`,
+      "Error al intentar obtener la reserva"
+    );
+  }
+
+  async crearReserva(
+    res: CrearReserva & { precio: Decimal }
+  ): Promise<Reserva> {
+    try {
+      const dbRes = await this.prisma.reserva.create({
+        data: {
+          id: undefined,
+          fechaReservada: res.fechaReservada,
+          precio: res.precio,
+          jugador: { connect: { id: res.idJugador } },
+          disponibilidad: { connect: { id: res.idDisponibilidad } },
+        },
+        include: this.include,
+      });
+
+      return toRes(dbRes);
+    } catch {
+      throw new InternalServerError("No se pudo crear la reserva");
+    }
+  }
+
+  /**
+   * Devuelve si una reserva de cierta disponibilidad en cierta fecha ya existe.
+   * Sirve para validar que la misma fecha de una disponibilidad no se reserve dos veces.
+   */
+  async existsReservaByDate(idDisp: number, fecha: Date): Promise<boolean> {
+    try {
+      const reserva = await this.prisma.reserva.findUnique({
+        where: {
+          idDisponibilidad_fechaReservada: {
+            idDisponibilidad: idDisp,
+            fechaReservada: fecha,
+          },
+        },
+        include: this.include,
+      });
+
+      return reserva !== null;
+    } catch {
+      throw new InternalServerError("Error al consultar la reserva en la DB");
+    }
+  }
+}
+
+type reservaDB = reserva & {
+  jugador: jugador;
+  disponibilidad: disponibilidadDB;
+};
+
+function toRes(res: reservaDB): Reserva {
+  const { clave, ...jugador } = res.jugador;
+  return { ...res, jugador, disponibilidad: toDisp(res.disponibilidad) };
+}
+
+async function awaitQuery(
+  promise: Promise<reservaDB | null>,
+  notFoundMsg: string,
+  errorMsg: string
+): Promise<Reserva> {
+  try {
+    const cancha = await promise;
+
+    if (cancha) {
+      return toRes(cancha);
+    }
+  } catch {
+    throw new InternalServerError(errorMsg);
+  }
+  throw new NotFoundError(notFoundMsg);
+}

--- a/backend/src/router.ts
+++ b/backend/src/router.ts
@@ -29,6 +29,10 @@ import { disponibilidadesRouter } from "./routers/disponibilidades.js";
 import { DisponibilidadHandler } from "./handlers/disponibilidades.js";
 import { PrismaDisponibilidadRepository } from "./repositories/disponibilidades.js";
 import { DisponibilidadServiceimpl } from "./services/disponibilidades.js";
+import { PrismaReservaRepository } from "./repositories/reservas.js";
+import { ReservaServiceImpl } from "./services/reservas.js";
+import { ReservaHandler } from "./handlers/reservas.js";
+import { reservasRouter } from "./routers/reservas.js";
 
 export function createRouter(prismaClient: PrismaClient): Router {
   const router = express.Router();
@@ -58,6 +62,10 @@ export function createRouter(prismaClient: PrismaClient): Router {
   const estService = new EstablecimientoServiceImpl(estRepo, adminService);
   const estHandler = new EstablecimientoHandler(estService);
 
+  const resRepo = new PrismaReservaRepository(prismaClient);
+  const resService = new ReservaServiceImpl(resRepo, canchaRepo, dispRepo);
+  const resHandler = new ReservaHandler(resService);
+
   const upload = multer({ dest: "imagenes/" });
 
   // Middlewares globales a todos los endpoints.
@@ -66,8 +74,8 @@ export function createRouter(prismaClient: PrismaClient): Router {
   router.use(express.urlencoded({ extended: true }));
   router.use(express.json());
 
-  // Ubicar los subrouters, normalmente uno por cada entidad.
-  router.use("/auth", authRouter(authHandler, authMiddle));
+  // Subrouters, normalmente uno por cada entidad.
+  router.use("/auth", authRouter(authHandler));
   router.use("/suscripciones", suscripcionesRouter(suscripcionHandler));
   router.use(
     "/administradores",
@@ -79,6 +87,7 @@ export function createRouter(prismaClient: PrismaClient): Router {
     canchasRouter(canchaHandler, estHandler, authMiddle, upload),
     disponibilidadesRouter(dispHandler, estHandler, authMiddle)
   );
+  router.use("/reservas", reservasRouter(resHandler, authMiddle));
 
   // Error handler global. Ataja los errores tirados por los otros handlers.
   router.use(handleApiErrors());

--- a/backend/src/routers/auth.ts
+++ b/backend/src/routers/auth.ts
@@ -1,20 +1,16 @@
 import express, { Router } from "express";
 import {
   AuthHandler,
-  loginReqSchema,
+  loginSchema,
   registrarAdminSchema,
   registrarJugadorSchema,
 } from "../handlers/auth.js";
 import { validateBody } from "../middlewares/validation.js";
-import { AuthMiddleware } from "../middlewares/auth.js";
 
-export function authRouter(
-  handler: AuthHandler,
-  authMiddle: AuthMiddleware
-): Router {
+export function authRouter(handler: AuthHandler): Router {
   const router = express.Router();
 
-  router.post("/login", validateBody(loginReqSchema), handler.login());
+  router.post("/login", validateBody(loginSchema), handler.login());
   router.post(
     "/register/administrador",
     validateBody(registrarAdminSchema),
@@ -25,7 +21,7 @@ export function authRouter(
     validateBody(registrarJugadorSchema),
     handler.registerJugador()
   );
-  router.get("/token", authMiddle.isAdmin(), handler.refreshToken());
+  router.get("/token", handler.refreshToken());
 
   return router;
 }

--- a/backend/src/routers/canchas.ts
+++ b/backend/src/routers/canchas.ts
@@ -2,8 +2,8 @@ import express from "express";
 import { Router } from "express";
 import {
   CanchaHandler,
-  crearCanchaReqSchema,
-  modificarCanchaReqSchema,
+  crearCanchaSchema,
+  modificarCanchaSchema,
 } from "../handlers/canchas.js";
 import multer from "multer";
 import { validateBody, validateIDParams } from "../middlewares/validation.js";
@@ -23,7 +23,7 @@ export function canchasRouter(
     "/:idEst/canchas/",
     authMiddle.isAdmin(),
     estHandler.validateAdminOwnsEstablecimiento(),
-    validateBody(crearCanchaReqSchema),
+    validateBody(crearCanchaSchema),
     handler.postCancha()
   );
 
@@ -36,7 +36,7 @@ export function canchasRouter(
     "/:idEst/canchas/:idCancha",
     authMiddle.isAdmin(),
     estHandler.validateAdminOwnsEstablecimiento(),
-    validateBody(modificarCanchaReqSchema),
+    validateBody(modificarCanchaSchema),
     handler.putCancha()
   );
   router.patch(

--- a/backend/src/routers/disponibilidades.ts
+++ b/backend/src/routers/disponibilidades.ts
@@ -5,8 +5,8 @@ import { EstablecimientoHandler } from "../handlers/establecimientos.js";
 import { AuthMiddleware } from "../middlewares/auth.js";
 import {
   DisponibilidadHandler,
-  crearDisponibilidadReqSchema,
-  modificarDisponibilidadReqSchema,
+  crearDisponibilidadSchema,
+  modificarDisponibilidadSchema,
 } from "../handlers/disponibilidades.js";
 
 export function disponibilidadesRouter(
@@ -22,7 +22,7 @@ export function disponibilidadesRouter(
   );
   router.post(
     "/:idEst/canchas/:idCancha/disponibilidades",
-    validateBody(crearDisponibilidadReqSchema),
+    validateBody(crearDisponibilidadSchema),
     handler.postDisponibilidad()
   );
 
@@ -39,7 +39,7 @@ export function disponibilidadesRouter(
     "/:idEst/canchas/:idCancha/disponibilidades/:idDisp",
     authMiddle.isAdmin(),
     estHandler.validateAdminOwnsEstablecimiento(),
-    validateBody(modificarDisponibilidadReqSchema),
+    validateBody(modificarDisponibilidadSchema),
     handler.putDisponibilidad()
   );
   router.delete(

--- a/backend/src/routers/establecimientos.ts
+++ b/backend/src/routers/establecimientos.ts
@@ -3,8 +3,8 @@ import { Router } from "express";
 import multer from "multer";
 import {
   EstablecimientoHandler,
-  crearEstablecimientoReqSchema,
-  modificarEstablecimientoReqSchema,
+  crearEstablecimientoSchema,
+  modificarEstablecimientoSchema,
 } from "../handlers/establecimientos.js";
 import { validateBody, validateIDParams } from "../middlewares/validation.js";
 import { AuthMiddleware } from "../middlewares/auth.js";
@@ -31,7 +31,7 @@ export function establecimientosRouter(
   router.post(
     "/",
     authMiddle.isAdmin(),
-    validateBody(crearEstablecimientoReqSchema),
+    validateBody(crearEstablecimientoSchema),
     handler.postEstablecimiento()
   );
 
@@ -41,7 +41,7 @@ export function establecimientosRouter(
     "/:idEst",
     authMiddle.isAdmin(),
     handler.validateAdminOwnsEstablecimiento(),
-    validateBody(modificarEstablecimientoReqSchema),
+    validateBody(modificarEstablecimientoSchema),
     handler.putEstablecimiento()
   );
   router.patch(

--- a/backend/src/routers/reservas.ts
+++ b/backend/src/routers/reservas.ts
@@ -1,0 +1,35 @@
+import express, { Router } from "express";
+import {
+  ReservaHandler,
+  crearReservaSchema,
+  getReservaQuerySchema,
+} from "../handlers/reservas.js";
+import { AuthMiddleware } from "../middlewares/auth";
+import {
+  validateBody,
+  validateIDParams,
+  validateQueryParams,
+} from "../middlewares/validation";
+
+export function reservasRouter(
+  handler: ReservaHandler,
+  authMiddle: AuthMiddleware
+): Router {
+  const router = express.Router();
+
+  router.get("/:idRes", validateIDParams("idRes"), handler.getReservaByID());
+  router.get(
+    "/",
+    validateQueryParams(getReservaQuerySchema),
+    handler.getReserva()
+  );
+
+  router.post(
+    "/",
+    authMiddle.isJugador(),
+    validateBody(crearReservaSchema),
+    handler.postReserva()
+  );
+
+  return router;
+}

--- a/backend/src/services/canchas.ts
+++ b/backend/src/services/canchas.ts
@@ -18,8 +18,8 @@ export interface CanchaService {
 export class CanchaServiceimpl implements CanchaService {
   private repo: CanchaRepository;
 
-  constructor(service: CanchaRepository) {
-    this.repo = service;
+  constructor(repository: CanchaRepository) {
+    this.repo = repository;
   }
 
   async getByEstablecimientoID(idEst: number) {

--- a/backend/src/services/disponibilidades.ts
+++ b/backend/src/services/disponibilidades.ts
@@ -12,8 +12,8 @@ export interface DisponibilidadService {
 export class DisponibilidadServiceimpl implements DisponibilidadService {
   private repo: DisponibilidadRepository;
 
-  constructor(service: DisponibilidadRepository) {
-    this.repo = service;
+  constructor(repository: DisponibilidadRepository) {
+    this.repo = repository;
   }
 
   async getByCanchaID(idCancha: number) {

--- a/backend/src/services/establecimientos.ts
+++ b/backend/src/services/establecimientos.ts
@@ -26,10 +26,10 @@ export class EstablecimientoServiceImpl implements EstablecimientoService {
   private adminService: AdministradorService;
 
   constructor(
-    repo: EstablecimientoRepository,
+    repository: EstablecimientoRepository,
     adminService: AdministradorService
   ) {
-    this.repo = repo;
+    this.repo = repository;
     this.adminService = adminService;
   }
 

--- a/backend/src/services/reservas.ts
+++ b/backend/src/services/reservas.ts
@@ -1,0 +1,103 @@
+import { Disponibilidad } from "../models/disponibilidad";
+import { Reserva } from "../models/reserva";
+import { CanchaRepository } from "../repositories/canchas";
+import { DisponibilidadRepository } from "../repositories/disponibilidades";
+import { ReservaRepository } from "../repositories/reservas";
+import { ConflictError } from "../utils/apierrors";
+import { getDayOfWeek } from "../utils/dates";
+
+export type CrearReserva = {
+  fechaReservada: Date;
+  idJugador: number;
+  idDisponibilidad: number;
+};
+
+export interface ReservaService {
+  getByEstablecimientoID(idEst: number): Promise<Reserva[]>;
+  getByDisponibilidadID(idDisp: number): Promise<Reserva[]>;
+  getByJugadorID(idJugador: number): Promise<Reserva[]>;
+  getByID(idRes: number): Promise<Reserva>;
+  crear(res: CrearReserva): Promise<Reserva>;
+}
+
+export class ReservaServiceImpl implements ReservaService {
+  private repo: ReservaRepository;
+  private canchaRepository: CanchaRepository;
+  private dispRepository: DisponibilidadRepository;
+
+  constructor(
+    repository: ReservaRepository,
+    canchaRepository: CanchaRepository,
+    dispRepository: DisponibilidadRepository
+  ) {
+    this.repo = repository;
+    this.canchaRepository = canchaRepository;
+    this.dispRepository = dispRepository;
+  }
+
+  async getByEstablecimientoID(idEst: number) {
+    return await this.repo.getReservasByEstablecimientoID(idEst);
+  }
+
+  async getByDisponibilidadID(idDisp: number) {
+    return await this.repo.getReservasByDisponibilidadID(idDisp);
+  }
+
+  async getByJugadorID(idJugador: number) {
+    return await this.repo.getReservasByJugadorID(idJugador);
+  }
+
+  async getByID(idRes: number) {
+    return await this.repo.getReservaByID(idRes);
+  }
+
+  async crear(crearReserva: CrearReserva) {
+    await this.validarCanchaHabilitada(crearReserva);
+    await this.validarDisponibilidadLibre(crearReserva);
+
+    const disp = await this.dispRepository.getDisponibilidadByID(
+      crearReserva.idDisponibilidad
+    );
+    await this.validarDiaDeSemana(crearReserva, disp);
+
+    return await this.repo.crearReserva({
+      ...crearReserva,
+      precio: disp.precioReserva,
+    });
+  }
+
+  /** Lanza error al intentar reservar una cancha deshabilitada o eliminada. */
+  private async validarCanchaHabilitada(res: CrearReserva) {
+    const cancha = await this.canchaRepository.getCanchaByDisponibilidadID(
+      res.idDisponibilidad
+    );
+    if (!cancha.habilitada || cancha.eliminada) {
+      throw new ConflictError(
+        `La disponibilidad ${res.idDisponibilidad} es de una cancha deshabilitada o eliminada`
+      );
+    }
+  }
+
+  /** Lanza error al intentar reservar una disponibilidad ya reservada en la fecha dada. */
+  private async validarDisponibilidadLibre(res: CrearReserva) {
+    const yaFueReservada = await this.repo.existsReservaByDate(
+      res.idDisponibilidad,
+      res.fechaReservada
+    );
+    if (yaFueReservada) {
+      throw new ConflictError(
+        `La disponibilidad ${res.idDisponibilidad} ya fue reservada en la fecha ${res.fechaReservada}`
+      );
+    }
+  }
+
+  /** Lanza error al intentar reservar una disponibilidad en un día de la semana no habilitado. */
+  private async validarDiaDeSemana(res: CrearReserva, disp: Disponibilidad) {
+    const dia = getDayOfWeek(res.fechaReservada);
+    if (!disp.dias.includes(dia)) {
+      throw new ConflictError(
+        `La disponibilidad ${res.idDisponibilidad} solo está disponible los días ${disp.dias}`
+      );
+    }
+  }
+}

--- a/backend/src/utils/dates.ts
+++ b/backend/src/utils/dates.ts
@@ -1,0 +1,16 @@
+import { Dia } from "../models/disponibilidad";
+
+const dias: Dia[] = [
+  Dia.Domingo,
+  Dia.Lunes,
+  Dia.Martes,
+  Dia.Miercoles,
+  Dia.Jueves,
+  Dia.Viernes,
+  Dia.Sabado,
+];
+
+/** Toma una fecha y devuelve qué `Dia` de la semana cae. Ej: 'Domingo', 'Lunes', 'Martes'. */
+export function getDayOfWeek(date: Date): Dia {
+  return dias[date.getDay()];
+}

--- a/frontend/src/models/domain.ts
+++ b/frontend/src/models/domain.ts
@@ -85,3 +85,12 @@ export type Tarjeta = {
   cvv: number;
   vencimiento: string;
 };
+
+export type Reserva = {
+  id: number;
+  fechaReservada: Date;
+  fechaCreada: Date;
+  precio: number;
+  jugador: Jugador;
+  disponibilidad: Disponibilidad;
+};

--- a/frontend/src/pages/ests/[idEst]/canchas/[idCancha]/disps/_formDisp.tsx
+++ b/frontend/src/pages/ests/[idEst]/canchas/[idCancha]/disps/_formDisp.tsx
@@ -52,8 +52,6 @@ export default function FormDisponibilidad({
     resetValues,
   });
 
-  console.log(methods.getValues());
-
   const button =
     variant === "crear" ? (
       <Button my="0.5em" leftIcon={<Icon as={GrAddCircle} />} onClick={onOpen}>

--- a/frontend/src/pages/ests/[idEst]/canchas/[idCancha]/disps/index.tsx
+++ b/frontend/src/pages/ests/[idEst]/canchas/[idCancha]/disps/index.tsx
@@ -112,8 +112,8 @@ export default function CanchaInfoPage() {
           de nuevo.
         </Alert>
       )}
-      <TableContainer pt="15px" pb="20px" mr="700px">
-        <Table variant="simple" m="auto" size="sm">
+      <TableContainer pt="15px" pb="20px" mr="100px">
+        <Table size="sm">
           <Thead>
             <Tr>
               <Th>Disciplina</Th>

--- a/frontend/src/utils/api/reservas.ts
+++ b/frontend/src/utils/api/reservas.ts
@@ -1,0 +1,66 @@
+import {
+  UseApiQueryOptions,
+  useApiQuery,
+  UseApiMutationOptions,
+  useApiMutation,
+} from "@/hooks";
+import { Reserva } from "@/models";
+import { API_URL, post } from ".";
+
+export type CrearReserva = {
+  idDisponibilidad: number;
+  idJugador: number;
+  fechaReservada: Date;
+};
+
+export function useReservasByEstablecimientoID(
+  idEst: number,
+  options?: UseApiQueryOptions<Reserva[]>
+) {
+  return useApiQuery(
+    ["reservas", "byEst", idEst],
+    `${API_URL}/reservas?idEst=${idEst}`,
+    { ...options, initialData: [] }
+  );
+}
+
+export function useReservasByDisponibilidadID(
+  idDisp: number,
+  options?: UseApiQueryOptions<Reserva[]>
+) {
+  return useApiQuery(
+    ["reservas", "byDisp", idDisp],
+    `${API_URL}/reservas?idDisp=${idDisp}`,
+    { ...options, initialData: [] }
+  );
+}
+
+export function useReservasByJugadorID(
+  idJugador: number,
+  options?: UseApiQueryOptions<Reserva[]>
+) {
+  return useApiQuery(
+    ["reservas", "byJugador", idJugador],
+    `${API_URL}/reservas?idJugador=${idJugador}`,
+    { ...options, initialData: [] }
+  );
+}
+
+export function useReservaByID(
+  idRes: number,
+  options?: UseApiQueryOptions<Reserva>
+) {
+  return useApiQuery(
+    ["reservas", idRes],
+    `${API_URL}/reservas/${idRes}`,
+    options
+  );
+}
+
+export function useCrearReserva(options?: UseApiMutationOptions<CrearReserva>) {
+  return useApiMutation({
+    ...options,
+    invalidateOnSuccess: () => ["reservas"],
+    mutationFn: (reserva) => post<Reserva>(`${API_URL}/reservas`, reserva),
+  });
+}


### PR DESCRIPTION
Nota: Las ramas `cambiar-clave` y `editar-jugador` construyen sobre esta PR.

Endpoints nuevos:
- POST `/reservas`.
- GET `/reservas/:idRes`.
- GET `/reservas` que acepta uno de los siguientes tres query params: `idDisp`, `idJugador` o `idEst`.

Creados los hooks `useCrearReserva`, `useReservaByID`, `useReservasByEstablecimientoID`, `useReservaByJugadorID` y `useReservaByDisponibilidadID` para consumir los endpoints del back end desde el front end.