### PR TITLE
Informe ingreso estimativo

### DIFF
--- a/backend/src/middlewares/errors.ts
+++ b/backend/src/middlewares/errors.ts
@@ -17,11 +17,11 @@ export function handleApiErrors(): ErrorRequestHandler {
   return (err: Error, req: Request, res: Response, _next: NextFunction) => {
     if (err instanceof ApiError) {
       logError(err, req, res);
-      res.status(err.status).json(err);
+      res.status(err.status).json(err.toJson());
     } else {
       const e = new InternalServerError(`Error desconocido: ${err.message}`);
       logError(e, req, res);
-      res.status(e.status).json(e);
+      res.status(e.status).json(e.toJson());
     }
   };
 }

--- a/backend/src/repositories/disponibilidades.ts
+++ b/backend/src/repositories/disponibilidades.ts
@@ -2,6 +2,7 @@ import { DIAS, Dia, Disponibilidad } from "../models/disponibilidad.js";
 import { BuscarDisponibilidadesQuery } from "../services/disponibilidades.js";
 import { InternalServerError, NotFoundError } from "../utils/apierrors.js";
 import { PrismaClient, dia, disciplina, disponibilidad } from "@prisma/client";
+import { getDiaDeSemana } from "../utils/dates.js";
 
 export interface DisponibilidadRepository {
   getByCanchaID(idCancha: number): Promise<Disponibilidad[]>;
@@ -77,9 +78,11 @@ export class PrismaDisponibilidadRepository
             ? {
                 // Solo trae disponibilidades no reservadas en la `fechaDisponible`.
                 reservas: {
-                  none: {
-                    fechaReservada: filtros.fechaDisponible,
-                  },
+                  none: { fechaReservada: filtros.fechaDisponible },
+                },
+                // Solo trae disponibilidades válidas para el día de `fechaDisponible`.
+                dias: {
+                  some: { dia: getDiaDeSemana(filtros.fechaDisponible) },
                 },
               }
             : {}),

--- a/backend/src/repositories/reservas.ts
+++ b/backend/src/repositories/reservas.ts
@@ -148,6 +148,10 @@ export class PrismaReservaRepository implements ReservaRepository {
             gte: filtros.fechaCreadaDesde,
             lte: filtros.fechaCreadaHasta,
           },
+          fechaReservada: {
+            gte: filtros.fechaReservadaDesde,
+            lte: filtros.fechaReservadaHasta,
+          },
           disponibilidad: {
             cancha: {
               id: filtros.idCancha,

--- a/backend/src/services/informes.ts
+++ b/backend/src/services/informes.ts
@@ -5,19 +5,22 @@ import { CanchaService } from "./canchas";
 import { EstablecimientoService } from "./establecimientos";
 import { ReservaService } from "./reservas";
 
-type IngresosPorCancha = Establecimiento & {
-  canchas: (Cancha & {
-    reservas: Reserva[];
-    total: number;
-  })[];
-  total: number;
-};
-
 export type PagosPorCanchaQuery = {
   idEst: number;
   fechaDesde?: string;
   fechaHasta?: string;
 };
+
+type IngresosPorCancha = Establecimiento & {
+  canchas: (Cancha & {
+    reservas: Reserva[];
+    estimado: number;
+    total: number;
+  })[];
+  estimado: number;
+  total: number;
+};
+
 export interface InformeService {
   ingresosPorCancha(query: PagosPorCanchaQuery): Promise<IngresosPorCancha>;
 }
@@ -40,7 +43,12 @@ export class InformeServiceImpl implements InformeService {
   async ingresosPorCancha(query: PagosPorCanchaQuery) {
     const est = await this.estService.getByID(query.idEst);
     const canchas = await this.canchaService.getByEstablecimientoID(est.id);
-    const res: IngresosPorCancha = { ...est, canchas: [], total: 0 };
+    const res: IngresosPorCancha = {
+      ...est,
+      canchas: [],
+      total: 0,
+      estimado: 0,
+    };
 
     for (const c of canchas) {
       let reservas = await this.reservaService.buscar({
@@ -49,15 +57,22 @@ export class InformeServiceImpl implements InformeService {
         fechaCreadaHasta: query.fechaHasta,
       });
 
+      const potencial = reservas.reduce((acum, r) => {
+        return acum + r.precio.toNumber();
+      }, 0);
+
       const total = reservas.reduce((acum, r) => {
         const senia = r.pagoSenia?.monto.toNumber() ?? 0;
         const monto = r.pagoReserva?.monto.toNumber() ?? 0;
         return acum + senia + monto;
       }, 0);
-      res.canchas.push({ ...c, reservas, total });
+
+      const estimado = potencial - total;
+      res.canchas.push({ ...c, reservas, total, estimado });
+      res.total += total;
+      res.estimado += estimado;
     }
 
-    res.total = res.canchas.reduce((acum, cancha) => acum + cancha.total, 0);
     return res;
   }
 }

--- a/backend/src/services/reservas.ts
+++ b/backend/src/services/reservas.ts
@@ -19,6 +19,8 @@ export type BuscarReservaQuery = {
   idEst?: number;
   fechaCreadaDesde?: string;
   fechaCreadaHasta?: string;
+  fechaReservadaDesde?: string;
+  fechaReservadaHasta?: string;
 };
 
 export interface ReservaService {

--- a/backend/src/utils/apierrors.ts
+++ b/backend/src/utils/apierrors.ts
@@ -7,6 +7,10 @@ export class ApiError extends Error {
     this.message = msg;
     this.status = status;
   }
+
+  toJson(): object {
+    return { status: this.status, message: this.message };
+  }
 }
 
 export class BadRequestError extends ApiError {

--- a/backend/src/utils/dates.ts
+++ b/backend/src/utils/dates.ts
@@ -12,7 +12,7 @@ const dias: Dia[] = [
 ];
 
 /** Convierte una fecha `Date` a otra fecha `Date` en UTC (Universal Coordinated Time).  */
-function convertDateToUTC(date: Date) {
+function convertDateToUTC(date: Date): Date {
   return new Date(
     date.getUTCFullYear(),
     date.getUTCMonth(),

--- a/frontend/src/components/display/ReservaCard.tsx
+++ b/frontend/src/components/display/ReservaCard.tsx
@@ -18,7 +18,7 @@ import {
 } from "@chakra-ui/react";
 import { Reserva } from "@/models";
 import { CircleIcon } from "../media-and-icons";
-import { formatearISO } from "@/utils/dates";
+import { formatISO } from "@/utils/dates";
 
 interface ReservaCardProps extends CardProps {
   reserva: Reserva;
@@ -115,7 +115,7 @@ function ReservaCardTags({ reserva }: { reserva: Reserva }) {
       </Tag>
       <Tag size="sm" variant="subtle" colorScheme="gray">
         <TagLeftIcon as={CalendarIcon} boxSize={4} />
-        <TagLabel>{formatearISO(reserva.fechaReservada)}</TagLabel>
+        <TagLabel>{formatISO(reserva.fechaReservada)}</TagLabel>
       </Tag>
       <Tag size="sm" variant="subtle" colorScheme="purple">
         <TagLabel> {reserva.disponibilidad.disciplina} </TagLabel>

--- a/frontend/src/components/forms/HorarioControl.tsx
+++ b/frontend/src/components/forms/HorarioControl.tsx
@@ -20,7 +20,7 @@ interface HorarioControlProps extends SelectControlProps {
 export default function HorarioControl(props: HorarioControlProps) {
   const { name, control, horas = HORAS, minutos = MINUTOS, ...rest } = props;
   const {
-    field: { onChange, value, ...restField },
+    field: { onChange, value, onBlur },
   } = useController({ name, control });
   const [hora, setHora] = useState(value?.split(":")[0] ?? "hh");
   const [minuto, setMinuto] = useState(value?.split(":")[1] ?? "mm");
@@ -35,7 +35,7 @@ export default function HorarioControl(props: HorarioControlProps) {
   };
 
   return (
-    <BaseFormControl control={control} {...rest} {...restField}>
+    <BaseFormControl control={control} {...rest} onBlur={onBlur} name={name}>
       <HStack>
         <Select
           maxW="max-content"

--- a/frontend/src/hooks/useBusqueda.tsx
+++ b/frontend/src/hooks/useBusqueda.tsx
@@ -1,4 +1,4 @@
-import { formatearFecha } from "@/utils/dates";
+import { formatFecha } from "@/utils/dates";
 import { useContext, createContext, useState, useMemo } from "react";
 import { useCurrentJugador } from ".";
 
@@ -35,7 +35,7 @@ const BusquedaContext = createContext<IBusquedaContext | undefined>(undefined);
 export function BusquedaProvider({ children }: BusquedaProviderProps) {
   const { jugador } = useCurrentJugador();
   const [filtros, updateFiltros] = useState<BusquedaFiltros>({
-    fecha: useMemo(() => formatearFecha(new Date()), []),
+    fecha: useMemo(() => formatFecha(new Date()), []),
     provincia: jugador.provincia,
   });
 

--- a/frontend/src/pages/ests/[idEst]/canchas/[idCancha]/disps/_FormEliminarDisp.tsx
+++ b/frontend/src/pages/ests/[idEst]/canchas/[idCancha]/disps/_FormEliminarDisp.tsx
@@ -18,14 +18,14 @@ export default function FormEliminarDisp({
     onSuccess: () => {
       toast({
         title: "Disponibilidad eliminada.",
-        description: `Disponibilidad eliminada exitosamente.`,
+        description: "Disponibilidad eliminada exitosamente.",
         status: "success",
       });
     },
     onError: () => {
       toast({
-        title: "Error al eliminar la cancha",
-        description: `Intente de nuevo.`,
+        title: "Error al eliminar la disponibilidad",
+        description: "Intente de nuevo.",
         status: "error",
       });
     },

--- a/frontend/src/pages/ests/[idEst]/informes/index.tsx
+++ b/frontend/src/pages/ests/[idEst]/informes/index.tsx
@@ -3,7 +3,7 @@ import { EstablecimientoMenu } from "@/components/navigation";
 import { useParams } from "@/router";
 import { useInformePagosPorCancha } from "@/utils/api";
 import { FallbackImage } from "@/utils/constants";
-import { formatearISOFecha } from "@/utils/dates";
+import { formatFecha, formatISOFecha } from "@/utils/dates";
 import {
   Box,
   Card,
@@ -19,19 +19,21 @@ import {
   StatHelpText,
   StatLabel,
   StatNumber,
+  Tooltip,
 } from "@chakra-ui/react";
 import { useState } from "react";
 
 export default function EstablecimientoReservasPage() {
   const { idEst } = useParams("/ests/:idEst/informes");
-  const [fechaDesde, setFechaDesde] = useState<string>("");
-  const [fechaHasta, setFechaHasta] = useState<string>("");
+  const [fechaDesde, setFechaDesde] = useState<string>(formatFecha(new Date()));
+  const [fechaHasta, setFechaHasta] = useState<string>(formatFecha(new Date()));
 
   const { data: informe } = useInformePagosPorCancha({
     idEst: Number(idEst),
     fechaDesde: fechaDesde || undefined,
     fechaHasta: fechaHasta || undefined,
   });
+  console.log(informe);
 
   const ingresosStat = (label: string, ingresos: number) => {
     return (
@@ -39,8 +41,8 @@ export default function EstablecimientoReservasPage() {
         <StatLabel>{label}</StatLabel>
         <StatNumber>${ingresos}</StatNumber>
         <StatHelpText>
-          {fechaDesde && formatearISOFecha(fechaDesde)} -{" "}
-          {fechaHasta && formatearISOFecha(fechaHasta)}
+          {fechaDesde && formatISOFecha(fechaDesde)} -{" "}
+          {fechaHasta && formatISOFecha(fechaHasta)}
         </StatHelpText>
       </Stat>
     );
@@ -52,8 +54,8 @@ export default function EstablecimientoReservasPage() {
         <StatLabel>{label}</StatLabel>
         <StatNumber>{reservas}</StatNumber>
         <StatHelpText>
-          {fechaDesde && formatearISOFecha(fechaDesde)} -{" "}
-          {fechaHasta && formatearISOFecha(fechaHasta)}
+          {fechaDesde && formatISOFecha(fechaDesde)} -{" "}
+          {fechaHasta && formatISOFecha(fechaHasta)}
         </StatHelpText>
       </Stat>
     );
@@ -87,12 +89,42 @@ export default function EstablecimientoReservasPage() {
         <LoadingSpinner />
       ) : (
         <Box mx="12%">
-          <StatGroup width="380px" gap="40px" m="20px auto">
-            {ingresosStat("Ingreso total", informe.total)}
-            {reservasStat(
-              "Reservas recibidas",
-              informe.canchas.reduce((acum, c) => acum + c.reservas.length, 0)
-            )}
+          <StatGroup width="450px" gap="40px" m="20px auto">
+            <Tooltip label="Dinero que se espera recibir al terminar el período, si todas las reservas son pagadas">
+              <Stat>
+                <StatLabel>Total estimado</StatLabel>
+                <StatNumber>${informe.estimado}</StatNumber>
+                <StatHelpText>
+                  {fechaDesde && formatISOFecha(fechaDesde)} -{" "}
+                  {fechaHasta && formatISOFecha(fechaHasta)}
+                </StatHelpText>
+              </Stat>
+            </Tooltip>
+            <Tooltip label="Cantidad de inero recibido por el establecimiento hasta ahora">
+              <Stat>
+                <StatLabel>Total ingresado</StatLabel>
+                <StatNumber>${informe.total}</StatNumber>
+                <StatHelpText>
+                  {fechaDesde && formatISOFecha(fechaDesde)} -{" "}
+                  {fechaHasta && formatISOFecha(fechaHasta)}
+                </StatHelpText>
+              </Stat>
+            </Tooltip>
+            <Tooltip label="Cantidad de reservas a ser usadas en el período de tiempo">
+              <Stat>
+                <StatLabel>Reservas recibidas</StatLabel>
+                <StatNumber>
+                  {informe.canchas.reduce(
+                    (acum, c) => acum + c.reservas.length,
+                    0
+                  )}
+                </StatNumber>
+                <StatHelpText>
+                  {fechaDesde && formatISOFecha(fechaDesde)} -{" "}
+                  {fechaHasta && formatISOFecha(fechaHasta)}
+                </StatHelpText>
+              </Stat>
+            </Tooltip>
           </StatGroup>
           <Heading size="lg" mb="0.5em" ml="2em">
             Por cancha
@@ -102,14 +134,15 @@ export default function EstablecimientoReservasPage() {
               <Card key={cancha.id} width="400px" borderRadius="10px">
                 <Image
                   src={cancha.urlImagen}
-                  fallback={<FallbackImage height="50px" />}
-                  height="50px"
+                  fallback={<FallbackImage height="125px" />}
+                  height="125px"
                   fit="cover"
                   borderRadius="10px 10px 0 0"
                 />
                 <CardBody>
                   <Heading size="md">{cancha.nombre}</Heading>
                   <StatGroup>
+                    {ingresosStat("Estimado", informe.estimado)}
                     {ingresosStat("Ingresos", cancha.total)}
                     {reservasStat("Reservas", cancha.reservas.length)}
                   </StatGroup>

--- a/frontend/src/pages/ests/[idEst]/reservas/[idReserva]/index.tsx
+++ b/frontend/src/pages/ests/[idEst]/reservas/[idReserva]/index.tsx
@@ -17,7 +17,7 @@ import {
   useSeniarReserva,
 } from "@/utils/api/reservas";
 import { ConfirmSubmitButton } from "@/components/forms";
-import { formatearISOFecha } from "@/utils/dates";
+import { formatISOFecha } from "@/utils/dates";
 import LoadingSpinner from "@/components/feedback/LoadingSpinner";
 import { CircleIcon } from "@/components/media-and-icons";
 import { useNavigate } from "react-router";
@@ -105,7 +105,7 @@ export default function ReservaInfoPage() {
             <Box>
               <Heading size="xs">Fecha</Heading>
               <Text fontSize="sm">
-                {formatearISOFecha(reserva.fechaReservada)}
+                {formatISOFecha(reserva.fechaReservada)}
               </Text>
             </Box>
             <Box>

--- a/frontend/src/pages/ests/[idEst]/reservas/index.tsx
+++ b/frontend/src/pages/ests/[idEst]/reservas/index.tsx
@@ -23,7 +23,7 @@ import {
 import { useNavigate } from "react-router";
 import { useParams } from "@/router";
 import { useReservasByEstablecimientoID } from "@/utils/api/reservas";
-import { formatearFecha, formatearISOFecha } from "@/utils/dates";
+import { formatFecha, formatISOFecha } from "@/utils/dates";
 import { useState } from "react";
 import { CircleIcon } from "@/components/media-and-icons";
 
@@ -85,7 +85,7 @@ export default function EstablecimientoReservasPage() {
   });
 
   const [filtroNombre, setFiltroNombre] = useState("");
-  const [filtroFecha, setFiltroFecha] = useState(formatearFecha(new Date()));
+  const [filtroFecha, setFiltroFecha] = useState(formatFecha(new Date()));
   const [filtroEstado, setFiltroEstado] = useState("");
 
   const reservasFiltradas = reservasOrdenadas.filter((r) => {
@@ -101,7 +101,7 @@ export default function EstablecimientoReservasPage() {
       .includes(filtroNombre.toLowerCase());
     const fechaCoincide =
       filtroFecha === "" ||
-      formatearISOFecha(r.fechaReservada) === formatearISOFecha(filtroFecha);
+      formatISOFecha(r.fechaReservada) === formatISOFecha(filtroFecha);
 
     var estadoCoincide = false;
     if (filtroEstado === estado && estado === "Pagado") {
@@ -142,7 +142,7 @@ export default function EstablecimientoReservasPage() {
             type="date"
             placeholder="Fecha"
             value={filtroFecha}
-            defaultValue={formatearFecha(new Date())}
+            defaultValue={formatFecha(new Date())}
             onChange={(e) => setFiltroFecha(e.target.value)}
           />
           <FormLabel>Fecha</FormLabel>
@@ -265,9 +265,7 @@ export default function EstablecimientoReservasPage() {
               return (
                 <Tr key={r.id}>
                   <Td textAlign="center">{r.disponibilidad.cancha?.nombre}</Td>
-                  <Td textAlign="center">
-                    {formatearISOFecha(r.fechaReservada)}
-                  </Td>
+                  <Td textAlign="center">{formatISOFecha(r.fechaReservada)}</Td>
                   <Td textAlign="center">
                     {r.jugador.nombre} {r.jugador.apellido}
                   </Td>

--- a/frontend/src/pages/search/est/[idEst]/canchas/[idCancha]/_formReservar.tsx
+++ b/frontend/src/pages/search/est/[idEst]/canchas/[idCancha]/_formReservar.tsx
@@ -3,7 +3,7 @@ import DateControl from "@/components/forms/DateControl";
 import { useYupForm } from "@/hooks";
 import { Disponibilidad } from "@/models";
 import { CrearReserva, useCrearReserva } from "@/utils/api";
-import { formatearFecha } from "@/utils/dates";
+import { formatFecha } from "@/utils/dates";
 import {
   useDisclosure,
   useToast,
@@ -63,7 +63,7 @@ export default function FormReservarDisponibilidad({
     validationSchema,
     defaultValues: {
       idDisponibilidad: disp.id,
-      fechaReservada: date || formatearFecha(new Date()),
+      fechaReservada: date || formatFecha(new Date()),
     },
   });
 

--- a/frontend/src/pages/search/est/[idEst]/canchas/[idCancha]/_formReservar.tsx
+++ b/frontend/src/pages/search/est/[idEst]/canchas/[idCancha]/_formReservar.tsx
@@ -1,6 +1,6 @@
 import { SubmitButton } from "@/components/forms";
 import DateControl from "@/components/forms/DateControl";
-import { useYupForm } from "@/hooks";
+import { useBusqueda, useYupForm } from "@/hooks";
 import { Disponibilidad } from "@/models";
 import { CrearReserva, useCrearReserva } from "@/utils/api";
 import { formatFecha } from "@/utils/dates";
@@ -41,6 +41,7 @@ export default function FormReservarDisponibilidad({
   const toast = useToast();
   const searchParams = new URLSearchParams(window.location.href);
   const date = searchParams.get("date")!;
+  const { filtros } = useBusqueda();
 
   const { mutate, isLoading } = useCrearReserva({
     onSuccess: () => {
@@ -63,7 +64,7 @@ export default function FormReservarDisponibilidad({
     validationSchema,
     defaultValues: {
       idDisponibilidad: disp.id,
-      fechaReservada: date || formatFecha(new Date()),
+      fechaReservada: filtros.fecha || date || formatFecha(new Date()),
     },
   });
 

--- a/frontend/src/pages/search/est/[idEst]/canchas/index.tsx
+++ b/frontend/src/pages/search/est/[idEst]/canchas/index.tsx
@@ -4,7 +4,7 @@ import { useEstablecimientoByID } from "@/utils/api";
 import { useCanchasByEstablecimientoID } from "@/utils/api";
 import { CanchaJugador } from "@/components/display";
 import { useLocation } from "react-router";
-import { formatearFecha } from "@/utils/dates";
+import { formatFecha } from "@/utils/dates";
 
 export default function VistaJugador() {
   const { idEst } = useParams();
@@ -13,7 +13,7 @@ export default function VistaJugador() {
 
   const location = useLocation();
   const dateParam = new URLSearchParams(location.search).get("date");
-  const date = formatearFecha(dateParam ? new Date(dateParam) : new Date());
+  const date = formatFecha(dateParam ? new Date(dateParam) : new Date());
 
   return (
     <>

--- a/frontend/src/pages/search/est/[idEst]/index.tsx
+++ b/frontend/src/pages/search/est/[idEst]/index.tsx
@@ -39,7 +39,8 @@ export default function EstablecimientoJugadorPage() {
           style={{ marginTop: "10px", marginBottom: "1rem" }}
           width="100%"
           display="flex"
-          flexDirection={{ base: "column", md: "row" }} // Cambio de dirección en dispositivos móviles
+          flexDirection={{ base: "column", md: "row" }}
+          // Cambio de dirección en dispositivos móviles
         >
           <CardHeader>
             <Box>

--- a/frontend/src/pages/search/est/[idEst]/reservar.tsx
+++ b/frontend/src/pages/search/est/[idEst]/reservar.tsx
@@ -77,7 +77,7 @@ export default function ReservarEstablecimientoPage() {
       </HStack>
 
       <Heading size="md">Horarios disponibles</Heading>
-      <Text>Seleccione un horario a reservar.</Text>
+      <Text mb="1em">Seleccione un horario a reservar.</Text>
       <TablaDisponibilidadesReservables data={disponibilidadesFiltradas} />
     </>
   );

--- a/frontend/src/pages/search/index.tsx
+++ b/frontend/src/pages/search/index.tsx
@@ -11,7 +11,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { formatearFecha } from "@/utils/dates";
+import { formatFecha } from "@/utils/dates";
 import { useYupForm } from "@/hooks";
 import { useWatch } from "react-hook-form";
 import { DISCIPLINAS, QuestionImage } from "@/utils/constants";
@@ -133,7 +133,7 @@ export default function BuscarEstablecimientosPage() {
             <EstablecimientoJugador
               key={est.id}
               establecimiento={est}
-              date={values.fecha ?? formatearFecha(new Date())}
+              date={values.fecha ?? formatFecha(new Date())}
             />
           ))
         ) : isFetchedAfterMount ? (

--- a/frontend/src/utils/api/disponibilidades.ts
+++ b/frontend/src/utils/api/disponibilidades.ts
@@ -22,7 +22,7 @@ export function useDisponibilidadesByCanchaID(
   options?: UseApiQueryOptions<Disponibilidad[]>
 ) {
   return useApiQuery(
-    ["canchas", idCancha, "disponibilidades"],
+    ["disponibilidades", "byCancha", idCancha],
     `${API_URL}/establecimientos/${idEst}/canchas/${idCancha}/disponibilidades`,
     { ...options, initialData: [] }
   );

--- a/frontend/src/utils/api/informes.ts
+++ b/frontend/src/utils/api/informes.ts
@@ -12,8 +12,10 @@ export type IngresosPorCanchaQuery = {
 type IngresosPorCancha = Establecimiento & {
   canchas: (Cancha & {
     reservas: Reserva[];
+    estimado: number;
     total: number;
   })[];
+  estimado: number;
   total: number;
 };
 

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -28,7 +28,7 @@ export function decimalAHora(n: number | undefined) {
 /**
  * Toma un objeto `Date` y devuelve la fecha como un string en formato `aaaa-MM-dd`.
  */
-export function formatearFecha(fecha: Date) {
+export function formatFecha(fecha: Date) {
   // Obtiene el día, el mes y el año de la fecha parseada
   const dia = fecha.getDate().toString().padStart(2, "0");
   const mes = (fecha.getMonth() + 1).toString().padStart(2, "0");
@@ -37,18 +37,30 @@ export function formatearFecha(fecha: Date) {
   return `${anio}-${mes}-${dia}`;
 }
 
+/** Convierte una fecha `Date` a otra fecha `Date` en UTC (Universal Coordinated Time).  */
+function convertDateToUTC(date: Date) {
+  return new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds()
+  );
+}
+
 /**
  * Toma un string de una fecha en formato ISO y devuelve solo la fecha (sin la hora) en formato local.
  * Usar esta función para mostrar la fecha al usuario de manera amigable.
  */
-export function formatearISOFecha(iso: string) {
-  return new Date(iso).toLocaleDateString("es-ar");
+export function formatISOFecha(iso: string) {
+  return convertDateToUTC(new Date(iso)).toLocaleDateString("es-ar");
 }
 
 /**
  * Toma un string de una fecha en formato ISO y devuelve la fecha y hora en formato local.
  * Usar esta función para mostrar la fecha al usuario de manera amigable.
  */
-export function formatearISO(iso: string) {
-  return new Date(iso).toLocaleString("es-ar");
+export function formatISO(iso: string) {
+  return convertDateToUTC(new Date(iso)).toLocaleString("es-ar");
 }


### PR DESCRIPTION
- El form de confirmar reserva, que se muestra al jugador para crear la reserva, ahora consume la fecha del `BusquedaContext`.
- Se agregó estadística `Total estimado` al informe de ingresos, que proyecta el ingreso total que el establecimiento recibiría si todas las reservas del período de tiempo seleccionado son pagadas. 
- El filtro `fechaDisponible` que se usa para buscar disponibilidades que no fueron reservadas en esa fecha ahora también filtra a las disponibilidades que no son válidas para ese día (ej: si la fecha cae un Martes, que no traiga una disponibilidad que solo se reserva Sábados o Domingos).
- Corregido el error de cálculo en la vista de creación de disponibilidades que hacía que la `horaInicio` no cambie.